### PR TITLE
Copy non-markdown files.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,4 +4,5 @@ align = none
 danglingParentheses = true
 newlines.neverBeforeJsNative = true
 newlines.sometimesBeforeColonInMethodReturnType = false
+assumeStandardLibraryStripMargin = true
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Docs
 
-```scala
+```scala vork
 case class User(name: String, age: Int)
-1.to(100).map(age => User("John", age))
+1.to(7).map(age => User("John", age))
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,5 +2,5 @@
 
 ```scala vork
 case class User(name: String, age: Int)
-1.to(7).map(age => User("John", age))
+1.to(7).map(age => User("Susan", age))
 ```

--- a/vork/src/main/resources/logback.xml
+++ b/vork/src/main/resources/logback.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <!-- Silence noise from logback on startup -->
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n
+      </Pattern>
+    </layout>
+  </appender>
+
+  <!-- Silence noise from directory watcher on startup/file events -->
+  <logger name="io.methvin.watcher" level="warn" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
+
+  <logger name="ch.qos.logback" level="debug" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/vork/src/main/scala/vork/Processor.scala
+++ b/vork/src/main/scala/vork/Processor.scala
@@ -2,6 +2,7 @@ package vork
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
 import com.vladsch.flexmark.formatter.internal.Formatter
@@ -37,11 +38,11 @@ final class Processor(
   }
 
   def handleRegularFile(path: Path): Unit = {
-    val out = options.resolveOut(path)
-    Files.createDirectories(out.getParent)
     val source = options.resolveIn(path)
-    Files.copy(source, out)
-    logger.info(s"Copied    $out")
+    val target = options.resolveOut(path)
+    Files.createDirectories(target.getParent)
+    Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING)
+    logger.info(s"Copied    $target")
   }
 
   def handlePath(path: Path): Unit = {

--- a/vork/src/main/scala/vork/utils/Decoders.scala
+++ b/vork/src/main/scala/vork/utils/Decoders.scala
@@ -6,6 +6,8 @@ import java.nio.charset.UnsupportedCharsetException
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.regex.PatternSyntaxException
+import scala.util.matching.Regex
 import metaconfig.ConfDecoder
 import metaconfig.ConfError
 import metaconfig.Configured
@@ -29,6 +31,16 @@ object Decoders {
         Configured.ok(Paths.get(str))
       } catch {
         case e: InvalidPathException =>
+          ConfError.message(e.getMessage).notOk
+      }
+    }
+
+  implicit val RegexDecoder: ConfDecoder[Regex] =
+    ConfDecoder.stringConfDecoder.flatMap { str =>
+      try {
+        Configured.ok(str.r)
+      } catch {
+        case e: PatternSyntaxException =>
           ConfError.message(e.getMessage).notOk
       }
     }

--- a/vork/src/main/scala/vork/utils/FilterMatcher.scala
+++ b/vork/src/main/scala/vork/utils/FilterMatcher.scala
@@ -1,0 +1,42 @@
+package vork.utils
+
+import java.nio.file.Path
+import scala.meta.io.AbsolutePath
+import scala.util.matching.Regex
+import metaconfig._
+
+case class FilterMatcher(
+    includeFilters: Regex,
+    excludeFilters: Regex
+) {
+  def matches(file: AbsolutePath): Boolean = matches(file.toString())
+  def matches(path: Path): Boolean = matches(path.toString)
+  def matches(input: String): Boolean =
+    includeFilters.findFirstIn(input).isDefined &&
+      excludeFilters.findFirstIn(input).isEmpty
+  def unapply(arg: String): Boolean =
+    matches(arg)
+}
+
+object FilterMatcher {
+  lazy val matchEverythingRegex: Regex = ".*".r
+  lazy val matchNothingRegex: Regex = mkRegexp(Nil)
+  lazy val matchEverything: FilterMatcher =
+    new FilterMatcher(includeFilters = matchEverythingRegex, excludeFilters = matchNothingRegex)
+  lazy val matchNothing: FilterMatcher =
+    new FilterMatcher(includeFilters = matchNothingRegex, excludeFilters = matchEverythingRegex)
+
+  def mkRegexp(filters: Seq[String]): Regex =
+    filters match {
+      case Nil => "$a".r // will never match anything
+      case head :: Nil => head.r
+      case _ => filters.mkString("(", "|", ")").r
+    }
+
+  def apply(includes: Seq[String], excludes: Seq[String]): FilterMatcher =
+    new FilterMatcher(mkRegexp(includes), mkRegexp(excludes))
+  def apply(include: String): FilterMatcher =
+    new FilterMatcher(mkRegexp(Seq(include)), mkRegexp(Nil))
+  def apply(include: Option[Regex], exclude: Option[Regex]): FilterMatcher =
+    new FilterMatcher(include.getOrElse(matchEverythingRegex), exclude.getOrElse(matchNothingRegex))
+}

--- a/vork/src/main/scala/vork/utils/IO.scala
+++ b/vork/src/main/scala/vork/utils/IO.scala
@@ -8,9 +8,12 @@ import vork.Options
 
 object IO {
 
-  def absolutize(path: Path, cwd: Path): Path =
-    if (path.isAbsolute) path
-    else cwd.resolve(path)
+  def absolutize(path: Path, cwd: Path): Path = {
+    val absolute =
+      if (path.isAbsolute) path
+      else cwd.resolve(path)
+    absolute.normalize()
+  }
 
   def collectInputPaths(options: Options): List[Path] = {
     val paths = List.newBuilder[Path]
@@ -21,9 +24,8 @@ object IO {
             file: Path,
             attrs: BasicFileAttributes
         ): FileVisitResult = {
-          if (Files.isRegularFile(file)
-            && file.getFileName.toString.endsWith(".md")) {
-            paths += options.in.relativize(file)
+          if (Files.isRegularFile(file)) {
+            paths += file
           }
           FileVisitResult.CONTINUE
         }

--- a/vork/src/main/scala/vork/utils/SourceWatcher.scala
+++ b/vork/src/main/scala/vork/utils/SourceWatcher.scala
@@ -21,8 +21,7 @@ object SourceWatcher {
       new DirectoryChangeListener {
         override def onEvent(event: DirectoryChangeEvent): Unit = {
           val targetFile = event.path()
-          val targetPath = targetFile.getFileName.toString
-          if (Files.isRegularFile(targetFile) && targetPath.endsWith(".md")) {
+          if (Files.isRegularFile(targetFile)) {
             event.eventType() match {
               case EventType.CREATE => runAction(event)
               case EventType.MODIFY => runAction(event)

--- a/vork/src/test/scala/vork/BaseCliSuite.scala
+++ b/vork/src/test/scala/vork/BaseCliSuite.scala
@@ -1,26 +1,29 @@
 package vork
 
 import java.nio.file.Files
+import java.nio.file.Path
 import scala.meta.testkit.DiffAssertions
 import org.langmeta.io.AbsolutePath
 import org.scalatest.FunSuite
 
+case class CliFixture(in: Path, out: Path)
 abstract class BaseCliSuite extends FunSuite with DiffAssertions {
   def checkCli(
       name: String,
       original: String,
       expected: String,
-      extraArgs: Array[String] = Array.empty
+      extraArgs: Array[String] = Array.empty,
+      setup: CliFixture => Unit = _ => ()
   ): Unit = {
     test(name) {
       val in = StringFS.string2dir(original)
       val out = Files.createTempDirectory("vork")
+      setup(CliFixture(in.toNIO, out))
       val args = Array[String](
         "--in",
         in.toString,
         "--out",
         out.toString,
-        "--clean-target",
         "--cwd",
         in.toString
       )

--- a/vork/src/test/scala/vork/BaseCliSuite.scala
+++ b/vork/src/test/scala/vork/BaseCliSuite.scala
@@ -1,0 +1,32 @@
+package vork
+
+import java.nio.file.Files
+import scala.meta.testkit.DiffAssertions
+import org.langmeta.io.AbsolutePath
+import org.scalatest.FunSuite
+
+abstract class BaseCliSuite extends FunSuite with DiffAssertions {
+  def checkCli(
+      name: String,
+      original: String,
+      expected: String,
+      extraArgs: Array[String] = Array.empty
+  ): Unit = {
+    test(name) {
+      val in = StringFS.string2dir(original)
+      val out = Files.createTempDirectory("vork")
+      val args = Array[String](
+        "--in",
+        in.toString,
+        "--out",
+        out.toString,
+        "--clean-target",
+        "--cwd",
+        in.toString
+      )
+      Cli.main(args ++ extraArgs)
+      val obtained = StringFS.dir2string(AbsolutePath(out))
+      assertNoDiff(obtained, expected)
+    }
+  }
+}

--- a/vork/src/test/scala/vork/CliArgsSuite.scala
+++ b/vork/src/test/scala/vork/CliArgsSuite.scala
@@ -1,0 +1,36 @@
+package vork
+
+import java.nio.file.Files
+import scala.meta.testkit.DiffAssertions
+import org.scalatest.FunSuite
+
+class CliArgsSuite extends FunSuite with DiffAssertions {
+
+  def checkError(args: List[String], expected: String): Unit = {
+    test(args.mkString(" ")) {
+      Options.fromCliArgs(args).toEither match {
+        case Left(obtained) =>
+          assertNoDiff(obtained.toString(), expected)
+        case Right(ok) =>
+          fail(s"Expected error. Obtained $ok")
+      }
+    }
+  }
+
+  checkError(
+    "--include-files" :: "*" :: Nil,
+    // TODO(olafur) automatically include flag name in metaconfig error message
+    """|Dangling meta character '*' near index 0
+       |*
+       |^
+       |""".stripMargin
+  )
+
+  private val tmp = Files.createTempDirectory("vork")
+  Files.delete(tmp)
+  checkError(
+    "--in" :: tmp.toString :: Nil,
+    s"File $tmp does not exist."
+  )
+
+}

--- a/vork/src/test/scala/vork/CliSuite.scala
+++ b/vork/src/test/scala/vork/CliSuite.scala
@@ -1,5 +1,7 @@
 package vork
 
+import java.nio.file.Files
+import org.langmeta.io.AbsolutePath
 import vork.internal.BuildInfo
 
 class CliSuite extends BaseCliSuite {
@@ -66,7 +68,7 @@ class CliSuite extends BaseCliSuite {
   )
 
   checkCli(
-    "non-markdown",
+    "copy-overwrite",
     """
       |/licence.txt
       |MIT
@@ -74,7 +76,11 @@ class CliSuite extends BaseCliSuite {
     """
       |/licence.txt
       |MIT
-    """.stripMargin
+    """.stripMargin,
+    setup = { fixture =>
+      // This file should be overwritten
+      Files.write(fixture.out.resolve("licence.txt"), "Apache".getBytes())
+    }
   )
 
 }

--- a/vork/src/test/scala/vork/CliSuite.scala
+++ b/vork/src/test/scala/vork/CliSuite.scala
@@ -1,36 +1,8 @@
 package vork
 
-import java.nio.file.Files
-import scala.meta.testkit.DiffAssertions
 import vork.internal.BuildInfo
-import org.langmeta.io.AbsolutePath
-import org.scalatest.FunSuite
 
-class CliSuite extends FunSuite with DiffAssertions {
-  def checkCli(
-      name: String,
-      original: String,
-      expected: String,
-      extraArgs: Array[String] = Array.empty,
-      setup: () => Unit = () => ()
-  ): Unit = {
-    test(name) {
-      val in = StringFS.string2dir(original)
-      val out = Files.createTempDirectory("vork")
-      val args = Array[String](
-        "--in",
-        in.toString,
-        "--out",
-        out.toString,
-        "--clean-target",
-        "--cwd",
-        in.toString
-      )
-      Cli.main(args ++ extraArgs)
-      val obtained = StringFS.dir2string(AbsolutePath(out))
-      assertNoDiff(obtained, expected)
-    }
-  }
+class CliSuite extends BaseCliSuite {
 
   checkCli(
     "vork.conf",
@@ -43,6 +15,10 @@ class CliSuite extends FunSuite with DiffAssertions {
     """
       |/index.md
       |# Hello 1.0
+      |
+      |
+      |/vork.conf
+      |site.version = "1.0"
     """.stripMargin
   )
 
@@ -65,6 +41,40 @@ class CliSuite extends FunSuite with DiffAssertions {
       "--classpath",
       BuildInfo.testsInputClassDirectory.getAbsolutePath
     )
+  )
+
+  checkCli(
+    "include/exclude",
+    """
+      |/include.md
+      |# Include
+      |/index.md
+      |# Index
+      |/include-exclude.md
+      |# Exclude
+    """.stripMargin,
+    """
+      |/include.md
+      |# Include
+    """.stripMargin,
+    extraArgs = Array(
+      "--include-files",
+      "include",
+      "--exclude-files",
+      "exclude"
+    )
+  )
+
+  checkCli(
+    "non-markdown",
+    """
+      |/licence.txt
+      |MIT
+    """.stripMargin,
+    """
+      |/licence.txt
+      |MIT
+    """.stripMargin
   )
 
 }

--- a/vork/src/test/scala/vork/markdown/processors/BaseMarkdownSuite.scala
+++ b/vork/src/test/scala/vork/markdown/processors/BaseMarkdownSuite.scala
@@ -8,7 +8,7 @@ import vork.{Markdown, Options, Processor}
 import scala.meta.testkit.DiffAssertions
 import scala.reflect.ClassTag
 
-class BaseMarkdownSuite extends org.scalatest.FunSuite with DiffAssertions {
+abstract class BaseMarkdownSuite extends org.scalatest.FunSuite with DiffAssertions {
   private val configPath = Paths.get(getClass.getClassLoader.getResource("vork.conf").toURI)
   private val options = Options.fromDefault(new Options(configPath = configPath)).get
   def getSettings(path: Path): MutableDataSet = {


### PR DESCRIPTION
Previously, we ran on all .md files. With this commit we handle all
files extensions:

* md files are processed
* other files are copied

To exclude/include certain files it's possible to use --include-files
and --exclude-files. This can be handle if you for example have a
massive node_modules directory from gitbook.