### PR TITLE
Make ammonite repl creation lazy.

### DIFF
--- a/vork/src/main/scala/vork/markdown/processors/AmmonitePostProcessor.scala
+++ b/vork/src/main/scala/vork/markdown/processors/AmmonitePostProcessor.scala
@@ -9,8 +9,12 @@ import vork.{Markdown, Options, Processor}
 import vork.markdown.repl.{AmmoniteRepl, RichCodeBlock, Evaluator, Position}
 
 class AmmonitePostProcessor(options: Options) extends DocumentPostProcessor {
-  private val repl = new AmmoniteRepl()
-  repl.loadClasspath(options.classpath)
+  // lazy to avoid instantiating a new repl for markdown files that have no ```scala vork code fences.
+  private lazy val repl = {
+    val r = new AmmoniteRepl()
+    r.loadClasspath(options.classpath)
+    r
+  }
   override def processDocument(doc: Document): Document = {
     import vork.Markdown._
     import scala.collection.JavaConverters._


### PR DESCRIPTION
Previously, we eagerly loaded a new ammonite repl for each document,
even if the document contained no vork code fences. This was
particularly bad for documents that use passthrough a lot because every
passthrough generates a new markdown document.