### PR TITLE
Add vscode-extension scaffold

### DIFF
--- a/vscode-extension/.gitignore
+++ b/vscode-extension/.gitignore
@@ -1,0 +1,4 @@
+out
+node_modules
+.vscode-test/
+.vsix

--- a/vscode-extension/.vscode/launch.json
+++ b/vscode-extension/.vscode/launch.json
@@ -1,0 +1,28 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+    "version": "0.1.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/**/*.js" ],
+            "preLaunchTask": "npm: watch"
+        },
+        {
+            "name": "Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
+            "preLaunchTask": "npm: watch"
+        }
+    ]
+}

--- a/vscode-extension/.vscode/settings.json
+++ b/vscode-extension/.vscode/settings.json
@@ -1,0 +1,9 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    }
+}

--- a/vscode-extension/.vscode/tasks.json
+++ b/vscode-extension/.vscode/tasks.json
@@ -1,0 +1,20 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -1,0 +1,8 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+out/**/*.map
+src/**
+.gitignore
+tsconfig.json
+vsc-extension-quickstart.md

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,13 @@
+# vork Visual Studio Code extension
+
+Live preview of Scala code snippets in VSCode markdown preview.
+
+## Try this out
+
+```sh
+cd vscode-extension
+npm install
+code .
+```
+
+Press `F5` to start the extension, then edit any markdown file and open the preview panel

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,0 +1,2663 @@
+{
+    "name": "vork",
+    "version": "0.0.1",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/markdown-it": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-0.0.4.tgz",
+            "integrity": "sha512-FWR7QB7EqBRq1s9BMk0ccOSOuRLfVEWYpHQYpFPaXtCoqN6dJx2ttdsdQbUxLLnAlKpYeVjveGGhQ3583TTa7g==",
+            "dev": true
+        },
+        "@types/mocha": {
+            "version": "2.2.47",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.47.tgz",
+            "integrity": "sha512-v/lko8AvmTt1K8p+ebdhdiHJE7zpPBYsDKjJSNCl8GwPGkKe5xND7s6M36LKye/USbWSPA7gYCDL0+DZ5h0L6Q==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "7.0.52",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.52.tgz",
+            "integrity": "sha512-jjpyQsKGsOF/wUElNjfPULk+d8PKvJOIXk3IUeBYYmNCy5dMWfrI+JiixYNw8ppKOlcRwWTXFl0B+i5oGrf95Q==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+            }
+        },
+        "ansi-cyan": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+            "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-gray": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-red": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+            "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "ansi-wrap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+            "dev": true
+        },
+        "arr-diff": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+            "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "1.1.0",
+                "array-slice": "0.2.3"
+            }
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+            "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+            "dev": true
+        },
+        "array-differ": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+            "dev": true
+        },
+        "array-slice": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
+        },
+        "assert-plus": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
+        },
+        "beeper": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+            "dev": true
+        },
+        "block-stream": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "boom": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "dev": true,
+            "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "dev": true
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+            }
+        },
+        "clone": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+            "dev": true
+        },
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+            "dev": true
+        },
+        "clone-stats": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+            "dev": true
+        },
+        "cloneable-readable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+            "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "process-nextick-args": "1.0.7",
+                "through2": "2.0.3"
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+            "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cryptiles": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "dateformat": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+            "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+            "dev": true
+        },
+        "debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "deep-assign": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+            "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
+            "dev": true,
+            "requires": {
+                "is-obj": "1.0.1"
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+            "dev": true
+        },
+        "duplexer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "dev": true
+        },
+        "duplexer2": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "1.1.14"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "duplexify": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+            "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "event-stream": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
+            }
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true,
+            "requires": {
+                "is-posix-bracket": "0.1.1"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true,
+            "requires": {
+                "fill-range": "2.2.3"
+            }
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+            "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+            "dev": true,
+            "requires": {
+                "kind-of": "1.1.0"
+            }
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "1.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fancy-log": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+            "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+            "dev": true,
+            "requires": {
+                "ansi-gray": "0.1.1",
+                "color-support": "1.1.3",
+                "time-stamp": "1.1.0"
+            }
+        },
+        "fast-deep-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fd-slicer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "dev": true,
+            "requires": {
+                "pend": "1.2.0"
+            }
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "fill-range": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "dev": true,
+            "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "first-chunk-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+            "dev": true
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2"
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "dev": true,
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+            }
+        },
+        "from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fstream": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+            }
+        },
+        "generate-function": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
+        },
+        "generate-object-property": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true,
+            "requires": {
+                "is-property": "1.0.2"
+            }
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "2.0.1"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                }
+            }
+        },
+        "glob-parent": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true,
+            "requires": {
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
+            }
+        },
+        "glob-stream": {
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+            "dev": true,
+            "requires": {
+                "extend": "3.0.1",
+                "glob": "5.0.15",
+                "glob-parent": "3.1.0",
+                "micromatch": "2.3.11",
+                "ordered-read-streams": "0.3.0",
+                "through2": "0.6.5",
+                "to-absolute-glob": "0.1.1",
+                "unique-stream": "2.2.1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
+        "glogg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+            "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+            "dev": true,
+            "requires": {
+                "sparkles": "1.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+            "dev": true
+        },
+        "gulp-chmod": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
+            "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
+            "dev": true,
+            "requires": {
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.3"
+            }
+        },
+        "gulp-filter": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
+            "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
+            "dev": true,
+            "requires": {
+                "multimatch": "2.1.0",
+                "plugin-error": "0.1.2",
+                "streamfilter": "1.0.7"
+            }
+        },
+        "gulp-gunzip": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
+            "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
+            "dev": true,
+            "requires": {
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
+        "gulp-remote-src": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
+            "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "node.extend": "1.1.6",
+                "request": "2.79.0",
+                "through2": "2.0.3",
+                "vinyl": "2.0.2"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.79.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.3.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.4.3",
+                        "uuid": "3.2.1"
+                    }
+                },
+                "vinyl": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+                    "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.0.0",
+                        "is-stream": "1.1.0",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
+                    }
+                }
+            }
+        },
+        "gulp-sourcemaps": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "1.5.1",
+                "graceful-fs": "4.1.11",
+                "strip-bom": "2.0.0",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                }
+            }
+        },
+        "gulp-symdest": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
+            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "mkdirp": "0.5.1",
+                "queue": "3.1.0",
+                "vinyl-fs": "2.4.4"
+            }
+        },
+        "gulp-untar": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
+            "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "gulp-util": "3.0.8",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.3"
+            }
+        },
+        "gulp-util": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+            "dev": true,
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-uniq": "1.0.3",
+                "beeper": "1.1.1",
+                "chalk": "1.1.3",
+                "dateformat": "2.2.0",
+                "fancy-log": "1.3.2",
+                "gulplog": "1.0.0",
+                "has-gulplog": "0.1.0",
+                "lodash._reescape": "3.0.0",
+                "lodash._reevaluate": "3.0.0",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.template": "3.6.2",
+                "minimist": "1.2.0",
+                "multipipe": "0.1.2",
+                "object-assign": "3.0.0",
+                "replace-ext": "0.0.1",
+                "through2": "2.0.3",
+                "vinyl": "0.5.3"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+                    "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                }
+            }
+        },
+        "gulp-vinyl-zip": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
+            "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "queue": "4.4.2",
+                "through2": "2.0.3",
+                "vinyl": "2.1.0",
+                "vinyl-fs": "2.4.4",
+                "yauzl": "2.9.1",
+                "yazl": "2.4.3"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "queue": {
+                    "version": "4.4.2",
+                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
+                    "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "vinyl": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.0.0",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
+                    }
+                }
+            }
+        },
+        "gulplog": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+            "dev": true,
+            "requires": {
+                "glogg": "1.0.1"
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "commander": "2.13.0",
+                "is-my-json-valid": "2.17.1",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+            "dev": true
+        },
+        "has-gulplog": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+            "dev": true,
+            "requires": {
+                "sparkles": "1.0.0"
+            }
+        },
+        "hawk": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+            }
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true
+        },
+        "hoek": {
+            "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+            "dev": true
+        },
+        "http-signature": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "is": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+            "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true,
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "2.1.1"
+            }
+        },
+        "is-my-json-valid": {
+            "version": "2.17.1",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+            "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+            "dev": true,
+            "requires": {
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "4.0.1"
+            }
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
+        },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-valid-glob": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true,
+            "requires": {
+                "isarray": "1.0.0"
+            }
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "requires": {
+                "jsonify": "0.0.0"
+            }
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonpointer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "kind-of": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+            "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+            "dev": true
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
+        },
+        "lodash._basecopy": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+            "dev": true
+        },
+        "lodash._basetostring": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+            "dev": true
+        },
+        "lodash._basevalues": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+            "dev": true
+        },
+        "lodash._getnative": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "dev": true
+        },
+        "lodash._isiterateecall": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+            "dev": true
+        },
+        "lodash._reescape": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+            "dev": true
+        },
+        "lodash._reevaluate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+            "dev": true
+        },
+        "lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+            "dev": true
+        },
+        "lodash._root": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+            "dev": true
+        },
+        "lodash.escape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+            "dev": true,
+            "requires": {
+                "lodash._root": "3.0.1"
+            }
+        },
+        "lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+            "dev": true
+        },
+        "lodash.isarray": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+            "dev": true
+        },
+        "lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "dev": true
+        },
+        "lodash.keys": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+            "dev": true,
+            "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+            }
+        },
+        "lodash.restparam": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+            "dev": true
+        },
+        "lodash.template": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
+            }
+        },
+        "lodash.templatesettings": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0"
+            }
+        },
+        "map-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+            "dev": true
+        },
+        "merge-stream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "dev": true,
+            "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "mime-db": {
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+            "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.17",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+            "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.30.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "1.1.8"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+            "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.0",
+                "commander": "2.11.0",
+                "debug": "3.1.0",
+                "diff": "3.3.1",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.3",
+                "he": "1.1.1",
+                "mkdirp": "0.5.1",
+                "supports-color": "4.4.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "2.0.0"
+                    }
+                }
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "multimatch": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+            "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+            "dev": true,
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
+            }
+        },
+        "multipipe": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "0.0.2"
+            }
+        },
+        "node.extend": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+            "dev": true,
+            "requires": {
+                "is": "3.2.1"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "1.1.0"
+            }
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true,
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "ordered-read-streams": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+            "dev": true,
+            "requires": {
+                "is-stream": "1.1.0",
+                "readable-stream": "2.3.3"
+            }
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                }
+            }
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
+        },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "plugin-error": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+            "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+            "dev": true,
+            "requires": {
+                "ansi-cyan": "0.1.1",
+                "ansi-red": "0.1.1",
+                "arr-diff": "1.1.0",
+                "arr-union": "2.1.0",
+                "extend-shallow": "1.1.4"
+            }
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+            "dev": true
+        },
+        "querystringify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+            "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+            "dev": true
+        },
+        "queue": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "randomatic": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "0.1.3"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "replace-ext": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+            "dev": true
+        },
+        "request": {
+            "version": "2.83.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true
+                },
+                "boom": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+                    "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+                    "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "5.2.0"
+                    },
+                    "dependencies": {
+                        "boom": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                            "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                            "dev": true,
+                            "requires": {
+                                "hoek": "4.2.0"
+                            }
+                        }
+                    }
+                },
+                "form-data": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+                    "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.17"
+                    }
+                },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
+                    }
+                },
+                "hawk": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+                    "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+                    "dev": true,
+                    "requires": {
+                        "boom": "4.3.1",
+                        "cryptiles": "3.1.2",
+                        "hoek": "4.2.0",
+                        "sntp": "2.1.0"
+                    }
+                },
+                "hoek": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+                    "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.13.1"
+                    }
+                },
+                "qs": {
+                    "version": "6.5.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+                    "dev": true
+                },
+                "sntp": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+                    "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "dev": true
+        },
+        "sntp": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+            "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+            "dev": true,
+            "requires": {
+                "source-map": "0.6.1"
+            }
+        },
+        "sparkles": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+            "dev": true
+        },
+        "split": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
+        },
+        "sshpk": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "dev": true,
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "stat-mode": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+            "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+            "dev": true
+        },
+        "stream-combiner": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1"
+            }
+        },
+        "stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "streamfilter": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
+            "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
+        },
+        "streamifier": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+            "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "0.2.1"
+            }
+        },
+        "strip-bom-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+            "dev": true,
+            "requires": {
+                "first-chunk-stream": "1.0.0",
+                "strip-bom": "2.0.0"
+            }
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "tar": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "dev": true,
+            "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+            }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+            }
+        },
+        "through2-filter": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+            "dev": true,
+            "requires": {
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            }
+        },
+        "time-stamp": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+            "dev": true
+        },
+        "to-absolute-glob": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "tough-cookie": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            }
+        },
+        "tunnel-agent": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+            "dev": true
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "typescript": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+            "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+            "dev": true
+        },
+        "unique-stream": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "1.0.1",
+                "through2-filter": "2.0.0"
+            }
+        },
+        "url-parse": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+            "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+            "dev": true,
+            "requires": {
+                "querystringify": "1.0.0",
+                "requires-port": "1.0.0"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+            "dev": true
+        },
+        "vali-date": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "vinyl": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+            "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+            "dev": true,
+            "requires": {
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
+            }
+        },
+        "vinyl-fs": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+            "dev": true,
+            "requires": {
+                "duplexify": "3.5.3",
+                "glob-stream": "5.3.5",
+                "graceful-fs": "4.1.11",
+                "gulp-sourcemaps": "1.6.0",
+                "is-valid-glob": "0.3.0",
+                "lazystream": "1.0.0",
+                "lodash.isequal": "4.5.0",
+                "merge-stream": "1.0.1",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "readable-stream": "2.3.3",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "1.0.0",
+                "through2": "2.0.3",
+                "through2-filter": "2.0.0",
+                "vali-date": "1.0.0",
+                "vinyl": "1.2.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                }
+            }
+        },
+        "vinyl-source-stream": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
+            "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
+            "dev": true,
+            "requires": {
+                "through2": "2.0.3",
+                "vinyl": "0.4.6"
+            }
+        },
+        "vscode": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.10.tgz",
+            "integrity": "sha512-MvFXXSGuhw0Q6GC6dQrnRc0ES+63wpttGIoYGBMQnoS9JFCCNC/rWfX0lBCHJyuKL2Q8CYg0ROsMEHbHVwEtVw==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.1.0",
+                "gulp-gunzip": "1.0.0",
+                "gulp-remote-src": "0.4.3",
+                "gulp-symdest": "1.1.0",
+                "gulp-untar": "0.0.6",
+                "gulp-vinyl-zip": "2.1.0",
+                "mocha": "4.1.0",
+                "request": "2.83.0",
+                "semver": "5.5.0",
+                "source-map-support": "0.5.3",
+                "url-parse": "1.2.0",
+                "vinyl-source-stream": "1.1.2"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "yauzl": {
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+            "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.0.1"
+            }
+        },
+        "yazl": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
+            "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13"
+            }
+        }
+    }
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "vork",
+  "displayName": "vork",
+  "description": "Markdown Scala Worksheets",
+  "version": "0.0.1",
+  "publisher": "vork",
+  "engines": {
+    "vscode": "^1.19.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "main": "./out/extension",
+  "activationEvents": [],
+  "contributes": {
+    "markdown.markdownItPlugins": true
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "npm run compile && node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "@types/markdown-it": "0.0.4",
+    "@types/mocha": "^2.2.42",
+    "@types/node": "^7.0.43",
+    "typescript": "^2.6.1",
+    "vscode": "^1.1.6"
+  }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,24 @@
+'use strict';
+
+import { ExtensionContext } from 'vscode';
+import { Options as MdOptions } from 'markdown-it';
+
+export function activate(context: ExtensionContext) {
+  return {
+    extendMarkdownIt(md: { options: MdOptions }) {
+      const defaultHighlight = md.options.highlight;
+      md.options.highlight = (code: string, lang: string) => {
+        if (lang && lang.match(/\bvork\b/i)) {
+          const codeToHighlight = [
+            code,
+            'ACTUAL VORK WILL BE HAPPENING HERE'
+          ].join('\n');
+          return defaultHighlight(codeToHighlight, 'scala');
+        } else {
+          return defaultHighlight(code, lang);
+        }
+      };
+      return md;
+    }
+  };
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "out",
+        "lib": [
+            "es6"
+        ],
+        "sourceMap": true,
+        "rootDir": "src"
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}


### PR DESCRIPTION
Just some boring scaffolding of the vscode extension.

Some notes: similarly to what [vscode-mermaid](https://github.com/mjbvz/vscode-markdown-mermaid) does, I'm intercepting the `highlight` function of markdown-it.
At a first look (also in markdown-it github issues) this functions needs to be synchronous.

Also, I think there's a way to make <code>```work</code> blocks to look like <code>```scala</code> in the editor, but I haven't investigated yet.

As always, you can try this with

```
cd vscode-extension
npm install
code .
F5
```

then open any markdown file and toggle the preview panel.

Stupid example:

![](http://g.recordit.co/zng1rKPlvE.gif)