### PR TITLE
Use book format instead of repl

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -7,8 +7,8 @@ part of your build. Distinguishing features of Vork include:
 
 - fast edit/preview workflow: each markdown file is compiled into a single
   source file and executed as a single program.
-- variable injection: use variables like `@@VERSION@` to make sure the
-  documentation always shows the latest version.
+- variable injection: instead of hardcoding constants, use variables like
+  `@@VERSION@` to make sure the documentation remains up-to-date.
 - extensible: library APIs expose hooks to customize rendering of code fences.
 - good error messages: compile errors and crashes are reported with positions of
   the original markdown source.
@@ -50,11 +50,10 @@ libraryDependencies += "com" % "lib" % "1.0.0"
 ```
 
 ```scala
-@ val x = 1
-x: Int = 1
-
-@ List(x, x)
-res0: List[Int] = List(1, 1)
+val x = 1
+// x: Int = 1
+List(x, x)
+// res0: List[Int] = List(1, 1)
 ```
 ````
 
@@ -191,9 +190,8 @@ val x = 1
 ```
 ````
 
-**Downside**: Vork is not a drop-in replacement for tut. If you have an existing
-tut-site that relies on REPL semantics then the code examples need to be
-refactored to avoid duplicate variable names.
+**Upside**: Code examples can be copy-pasted into normal Scala programs and
+compile.
 
 **Upside**: Companion objects Just Work™️
 

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,8 @@ part of your build. Distinguishing features of Vork include:
 
 - fast edit/preview workflow: each markdown file is compiled into a single
   source file and executed as a single program.
-- variable injection: use variables like `@VERSION@` to make sure the
-  documentation always shows the latest version.
+- variable injection: instead of hardcoding constants, use variables like
+  `@VERSION@` to make sure the documentation remains up-to-date.
 - extensible: library APIs expose hooks to customize rendering of code fences.
 - good error messages: compile errors and crashes are reported with positions of
   the original markdown source.
@@ -51,11 +51,10 @@ libraryDependencies += "com" % "lib" % "1.0.0"
 ```
 
 ```scala
-@ val x = 1
-x: Int = 1
-
-@ List(x, x)
-res0: List[Int] = List(1, 1)
+val x = 1
+// x: Int = 1
+List(x, x)
+// res0: List[Int] = List(1, 1)
 ```
 ````
 
@@ -122,14 +121,14 @@ After:
 
 ````
 ```scala
-@ val x = 1
-x: Int = 1
+val x = 1
+// x: Int = 1
 
-@ val y = 2
-y: Int = 2
+val y = 2
+// y: Int = 2
 
-@ x + y
-res0: Int = 3
+x + y
+// res0: Int = 3
 ```
 ````
 
@@ -151,12 +150,12 @@ After:
 
 ````
 ```scala
-@ val x: Int = ""
-type mismatch;
- found   : String("")
- required: Int
 val x: Int = ""
-             ^
+// type mismatch;
+//  found   : String("")
+//  required: Int
+// val x: Int = ""
+//              ^
 ```
 ````
 
@@ -181,10 +180,10 @@ After:
 ````
 ```scala
 val y = ???
-scala.NotImplementedError: an implementation is missing
-	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:284)
-	at repl.Session.$anonfun$app$1(readme.md:8)
-	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
+// scala.NotImplementedError: an implementation is missing
+// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:284)
+// 	at repl.Session.$anonfun$app$1(readme.md:8)
+// 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
 ```
 ````
 
@@ -278,9 +277,8 @@ val x = 1
 ```
 ````
 
-**Downside**: Vork is not a drop-in replacement for tut. If you have an existing
-tut-site that relies on REPL semantics then the code examples need to be
-refactored to avoid duplicate variable names.
+**Upside**: Code examples can be copy-pasted into normal Scala programs and
+compile.
 
 **Upside**: Companion objects Just Work™️
 
@@ -301,12 +299,12 @@ After:
 
 ````
 ```scala
-@ case class User(name: String)
+case class User(name: String)
 
-@ object User { implicit val ordering: Ordering[User] = Ordering.by(_.name) }
+object User { implicit val ordering: Ordering[User] = Ordering.by(_.name) }
 
-@ List(User("John"), User("Susan")).sorted
-res0: List[User] = List(User("John"), User("Susan"))
+List(User("John"), User("Susan")).sorted
+// res0: List[User] = List(User("John"), User("Susan"))
 ```
 ````
 

--- a/tests/unit/src/test/scala/tests/cli/CliSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/CliSuite.scala
@@ -16,8 +16,8 @@ class CliSuite extends BaseCliSuite {
     """
       |/index.md
       |```scala
-      |@ test.Test.greeting
-      |res0: String = "Hello world!"
+      |test.Test.greeting
+      |// res0: String = "Hello world!"
       |```
     """.stripMargin,
     extraArgs = Array(

--- a/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
@@ -47,7 +47,7 @@ abstract class BaseMarkdownSuite extends org.scalatest.FunSuite with DiffAsserti
       Markdown.toMarkdown(input, getSettings, reporter, settings)
       assert(reporter.hasErrors, "Expected errors but reporter.hasErrors=false")
       val obtainedErrors = fansi.Str(myStdout.toString).plainText.trimLineEnds
-      assertNoDiff(obtainedErrors, expected)
+      assertNoDiffOrPrintExpected(obtainedErrors, expected)
     }
   }
 
@@ -58,7 +58,7 @@ abstract class BaseMarkdownSuite extends org.scalatest.FunSuite with DiffAsserti
       val obtained = Markdown.toMarkdown(input, getSettings, reporter, settings).trimLineEnds
       val stdout = fansi.Str(myStdout.toString()).plainText
       assert(!reporter.hasErrors, stdout)
-      assertNoDiff(obtained, expected)
+      assertNoDiffOrPrintExpected(obtained, expected)
     }
   }
 }

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -13,9 +13,9 @@ class CrashSuite extends BaseMarkdownSuite {
       |```scala
       |val x = 1
       |???
-      |scala.NotImplementedError: an implementation is missing
-      |	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:284)
-      |	at repl.Session.$anonfun$app$2(basic.md:13)
+      |// scala.NotImplementedError: an implementation is missing
+      |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:284)
+      |// 	at repl.Session.$anonfun$app$2(basic.md:13)
       |```
     """.stripMargin
   )

--- a/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
@@ -9,11 +9,10 @@ class DefaultSuite extends BaseMarkdownSuite {
       |val x = List(1).map(_ + 1)
       |```
     """.stripMargin,
-    """
-      |```scala
-      |@ val x = List(1).map(_ + 1)
-      |x: List[Int] = List(2)
-      |```
+    """|```scala
+       |val x = List(1).map(_ + 1)
+       |// x: List[Int] = List(2)
+       |```
     """.stripMargin
   )
 
@@ -30,18 +29,17 @@ class DefaultSuite extends BaseMarkdownSuite {
       |val ys = xs.map(_ * 2)
       |```
     """.stripMargin,
-    """
-      |# Hey Scala!
-      |
-      |```scala
-      |@ val xs = List(1, 2, 3)
-      |xs: List[Int] = List(1, 2, 3)
-      |```
-      |
-      |```scala
-      |@ val ys = xs.map(_ * 2)
-      |ys: List[Int] = List(2, 4, 6)
-      |```
+    """|# Hey Scala!
+       |
+       |```scala
+       |val xs = List(1, 2, 3)
+       |// xs: List[Int] = List(1, 2, 3)
+       |```
+       |
+       |```scala
+       |val ys = xs.map(_ * 2)
+       |// ys: List[Int] = List(2, 4, 6)
+       |```
     """.stripMargin
   )
 
@@ -57,20 +55,18 @@ class DefaultSuite extends BaseMarkdownSuite {
       |println(1)
       |```
       """.stripMargin,
-    """
-      |```scala
-      |@ List(1).map(_ + 1)
-      |res0: List[Int] = List(2)
-      |
-      |@ res0.length
-      |res1: Int = 1
-      |```
-      |
-      |```scala
-      |@ println(1)
-      |1
-      |res2: Unit = ()
-      |```
+    """|```scala
+       |List(1).map(_ + 1)
+       |// res0: List[Int] = List(2)
+       |
+       |res0.length
+       |// res1: Int = 1
+       |```
+       |
+       |```scala
+       |println(1)
+       |// 1
+       |```
       """.stripMargin
   )
 
@@ -82,13 +78,12 @@ class DefaultSuite extends BaseMarkdownSuite {
       |User("John", 42)
       |```
     """.stripMargin,
-    """
-      |```scala
-      |@ case class User(name: String, age: Int)
-      |
-      |@ User("John", 42)
-      |res0: User = User("John", 42)
-      |```
+    """|```scala
+       |case class User(name: String, age: Int)
+       |
+       |User("John", 42)
+       |// res0: User = User("John", 42)
+       |```
     """.stripMargin
   )
 
@@ -100,13 +95,12 @@ class DefaultSuite extends BaseMarkdownSuite {
       |Future.successful(1)
       |```
     """.stripMargin,
-    """
-      |```scala
-      |@ import scala.concurrent.Future
-      |
-      |@ Future.successful(1)
-      |res0: Future[Int] = Future(Success(1))
-      |```
+    """|```scala
+       |import scala.concurrent.Future
+       |
+       |Future.successful(1)
+       |// res0: Future[Int] = Future(Success(1))
+       |```
     """.stripMargin
   )
 
@@ -122,82 +116,18 @@ class DefaultSuite extends BaseMarkdownSuite {
       |println(x)
       |```
     """.stripMargin.replace("'''", "\"\"\""),
-    """
-      |```scala
-      |@ println(1)
-      |1
-      |res0: Unit = ()
-      |
-      |@ val x = 42
-      |x: Int = 42
-      |```
-      |
-      |```scala
-      |@ println(x)
-      |42
-      |res1: Unit = ()
-      |```
-    """.stripMargin
-  )
-
-  check(
-    "script",
-    """
-      |```scala vork
-      |val x = 1
-      |val y = 2
-      |x + y
-      |```
-      |
-      |```scala vork:fail
-      |val x: Int = ""
-      |```
-      |
-      |```scala vork:crash
-      |???
-      |```
-      |
-      |```scala vork
-      |val List(z, zz) = List(3, 4)
-      |x + y + z + zz
-      |```
-    """.stripMargin,
-    """
-      |```scala
-      |@ val x = 1
-      |x: Int = 1
-      |
-      |@ val y = 2
-      |y: Int = 2
-      |
-      |@ x + y
-      |res0: Int = 3
-      |```
-      |
-      |```scala
-      |@ val x: Int = ""
-      |type mismatch;
-      | found   : String("")
-      | required: Int
-      |val x = 1
-      |         ^
-      |```
-      |
-      |```scala
-      |???
-      |scala.NotImplementedError: an implementation is missing
-      |	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:284)
-      |	at repl.Session.$anonfun$app$5(script.md:26)
-      |```
-      |
-      |```scala
-      |@ val List(z, zz) = List(3, 4)
-      |z: Int = 3
-      |zz: Int = 4
-      |
-      |@ x + y + z + zz
-      |res2: Int = 10
-      |```
+    """|```scala
+       |println(1)
+       |// 1
+       |
+       |val x = 42
+       |// x: Int = 42
+       |```
+       |
+       |```scala
+       |println(x)
+       |// 42
+       |```
     """.stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
@@ -13,12 +13,12 @@ class FailSuite extends BaseMarkdownSuite {
     """.stripMargin,
     """
       |```scala
-      |@ val x: Int = "String"
-      |type mismatch;
-      | found   : String("String")
-      | required: Int
       |val x: Int = "String"
-      |             ^
+      |// type mismatch;
+      |//  found   : String("String")
+      |//  required: Int
+      |// val x: Int = "String"
+      |//              ^
       |```
     """.stripMargin
   )
@@ -34,14 +34,14 @@ class FailSuite extends BaseMarkdownSuite {
     """.stripMargin.triplequoted,
     """
       |```scala
-      |@ val y: Int = '''Triplequote
+      |val y: Int = '''Triplequote
       |newlines
       |'''
-      |type mismatch;
-      | found   : String("Triplequote\nnewlines\n")
-      | required: Int
-      |val y: Int = '''Triplequote
-      |             ^
+      |// type mismatch;
+      |//  found   : String("Triplequote\nnewlines\n")
+      |//  required: Int
+      |// val y: Int = '''Triplequote
+      |//              ^
       |```
       |""".stripMargin.triplequoted
   )

--- a/tests/unit/src/test/scala/tests/markdown/MarkdownCompilerSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/MarkdownCompilerSuite.scala
@@ -38,12 +38,12 @@ class MarkdownCompilerSuite extends FunSuite with DiffAssertions {
     ),
     """
       |```scala
-      |@ val x = 1.to(10)
-      |x: Range.Inclusive = Range.Inclusive(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+      |val x = 1.to(10)
+      |// x: Range.Inclusive = Range.Inclusive(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
       |```
       |```scala
-      |@ val y = x.length
-      |y: Int = 10
+      |val y = x.length
+      |// y: Int = 10
       |```
     """.stripMargin
   )
@@ -60,15 +60,15 @@ class MarkdownCompilerSuite extends FunSuite with DiffAssertions {
     """.stripMargin,
     """
       |```scala
-      |@ val x = {
+      |val x = {
       |  println(42)
       |  System.err.println("err")
       |  println(52)
       |  2
       |}
-      |42
-      |52
-      |x: Int = 2
+      |// 42
+      |// 52
+      |// x: Int = 2
       |```
     """.stripMargin
   )
@@ -78,9 +78,8 @@ class MarkdownCompilerSuite extends FunSuite with DiffAssertions {
     """println("hello world!") """,
     """
       |```scala
-      |@ println("hello world!")
-      |hello world!
-      |res0: Unit = ()
+      |println("hello world!")
+      |// hello world!
       |```
       |""".stripMargin
   )

--- a/tests/unit/src/test/scala/tests/markdown/VariableRegexSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/VariableRegexSuite.scala
@@ -40,11 +40,11 @@ class VariableRegexSuite extends BaseMarkdownSuite {
     """.stripMargin,
     """
       |```scala
-      |@ val x = "1.0"
-      |x: String = "1.0"
+      |val x = "1.0"
+      |// x: String = "1.0"
       |
-      |@ x.length
-      |res0: Int = 3
+      |x.length
+      |// res0: Int = 3
       |```
     """.stripMargin,
   )


### PR DESCRIPTION
This makes it possible to copy-paste code examples into a program.
The REPL printout was also confusing with regards to how companion
objects were printed out because the REPL does not support companion
objects.